### PR TITLE
remove rodjek-logrotate dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -37,7 +37,6 @@
   "dependencies": [
     {"name":"puppetlabs/stdlib","version_requirement":">= 4.2.0"},
     {"name":"puppetlabs/apache","version_requirement":">= 1.0.1"},
-    {"name":"rodjek/logrotate","version_requirement":">= 1.1.1"},
     {"name":"stankevich/python","version_requirement":">= 1.7.5"}
   ]
 


### PR DESCRIPTION
This appears to be dropped in master and upstream.
