### PR TITLE
Init scripts ignoring gr_carbon_relay_ulimit

### DIFF
--- a/templates/etc/init.d/Debian/carbon-relay.erb
+++ b/templates/etc/init.d/Debian/carbon-relay.erb
@@ -31,8 +31,8 @@ case "${OPERATION}" in
             if [ "${INSTANCE}" = "${CARBON_DAEMON}" ]; then
                 INSTANCE="a";
             fi;
-            <% if @gr_carbon_relay_ulimit -%>
-              ulimit -n <%= @gr_carbon_relay_ulimit %>
+            <% if scope.lookupvar('graphite::gr_carbon_relay_ulimit') -%>
+                ulimit -n <%= scope.lookupvar('graphite::gr_carbon_relay_ulimit') %>
             <% end -%>
             ${PYTHON_CMD} ${GRAPHITE_DIR}/bin/carbon-${CARBON_DAEMON}.py --instance=${INSTANCE} start
         done

--- a/templates/etc/init.d/RedHat/carbon-relay.erb
+++ b/templates/etc/init.d/RedHat/carbon-relay.erb
@@ -38,8 +38,8 @@ start()
         if [ "${INSTANCE}" = "${CARBON_DAEMON}" ]; then
             INSTANCE="a";
         fi;
-        <% if @gr_carbon_relay_ulimit -%>
-          ulimit -n <%= @gr_carbon_relay_ulimit %>
+        <% if scope.lookupvar('graphite::gr_carbon_relay_ulimit') -%>
+            ulimit -n <%= scope.lookupvar('graphite::gr_carbon_relay_ulimit') %>
         <% end -%>
         pidfile=${PIDFILE_DIR}/carbon-${CARBON_DAEMON}-${INSTANCE}.pid
         prog=carbon-${CARBON_DAEMON}-${INSTANCE}


### PR DESCRIPTION
The gr_carbon_relay_ulimit parameter is defined in init.pp, but the init script is rendered from config.pp. In order to make the variable visible, I switched from '@' syntax to scope.lookupvar.